### PR TITLE
fix: remove callbackify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const {callbackify} = require('util');
 const verifyMeteor = require('./lib/verify');
 const publishMeteor = require('./lib/publish');
 const getLastReleaseMeteor = require('./lib/get-last-release');
@@ -27,7 +26,7 @@ async function publish (pluginConfig, {pkg, nextRelease: {version}, logger}) {
 }
 
 module.exports = {
-  verifyConditions: callbackify(verifyConditions),
-  getLastRelease: callbackify(getLastRelease),
-  publish: callbackify(publish)
+  verifyConditions: verifyConditions,
+  getLastRelease: getLastRelease,
+  publish: publish
 };


### PR DESCRIPTION
Hey @raix ! I tried setting this up for meteortesting:mocha and got

```
An error occurred while running semantic-release: { TypeError [ERR_INVALID_ARG_TYPE]: The "last argument" argument must be of type function
    at verifyConditions (util.js:1080:13)
    at Object.defineProperty (/home/circleci/.npm/_npx/97/lib/node_modules/semantic-release/lib/plugins/normalize.js:44:30)
    at pReduce (/home/circleci/.npm/_npx/97/lib/node_modules/semantic-release/lib/plugins/pipeline.js:36:40)
    at Promise.all.then.value (/home/circleci/.npm/_npx/97/lib/node_modules/semantic-release/node_modules/p-reduce/index.js:16:10)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7) pluginName: 'semantic-release-meteor' }
```

https://circleci.com/gh/meteortesting/meteor-mocha/12

See https://github.com/shroudedcode/semantic-release-apm/issues/4#issuecomment-350501065

I think this change will fix, but I didn't test.